### PR TITLE
Validator-klasser for å lette bruken av validatoren

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ Hvis din html har feil i html vil funksjonen kaste `HTMLValidationException`. Og
 arver fra `ValidationException` som er en `RuntimeException` og har metoden `getValidationErrors` for å hente ut feilene i dokumentet.
 Se `DigipostValidatingHtmlSanitizerTest` for basic eksempel.  
 
+Det går også an bruke en instans av `HtmlValidator.java`:
+```java
+HtmlValidationResult validationResult = new HtmlValidator().valider("<html></html>".getBytes());
+
+if(validationResult.okForWeb){
+    //Cool! Det kan sendes inn
+} else {
+    System.err.println(validationResult.toString()); // vil skrive ut meldingene fra exception
+}
+
+if(validationResult.hasDiffAfterSanitizing){ // Din html er endret på og er fremdele ok å sende inn.
+    System.out.println(validationResult.toString()); // vil skrive ut den nye html-en som du så kan bruke til å endre din html.
+}
+```
+
 # Hvorfor vasker vi HTML-kode som blir sendt til Digipost
 Generelt endrer vi ikke på innhold som blir sendt gjennom Digipost. Men HTML-validering er vanskelig. Å sørge
 for at HTML er vasket er mye enklere (se [https://github.com/OWASP/java-html-sanitizer/blob/master/docs/html-validation.md](https://github.com/OWASP/java-html-sanitizer/blob/f1c32172208e29c970d2cdfdd6be48d6d44d3646/docs/html-validation.md).

--- a/src/main/java/no/digipost/sanitizing/HtmlValidationResult.java
+++ b/src/main/java/no/digipost/sanitizing/HtmlValidationResult.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) Posten Norge AS
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.sanitizing;
+
+import no.digipost.sanitizing.exception.ValidationException;
+
+import java.util.Collections;
+import java.util.List;
+
+public class HtmlValidationResult {
+    public static final HtmlValidationResult HTML_EVERYTHING_OK = new HtmlValidationResult(true, false);
+
+    public final boolean okForWeb;
+    public final boolean hasDiffAfterSanitizing;
+    private final List<String> validationErrors;
+    private final String output;
+
+    public HtmlValidationResult(boolean okForWeb, boolean hasDiffAfterSanitizing) {
+        this.okForWeb = okForWeb;
+        this.hasDiffAfterSanitizing = hasDiffAfterSanitizing;
+        this.validationErrors = Collections.emptyList();
+        this.output = "";
+    }
+
+    public HtmlValidationResult(ValidationException e) {
+        this.okForWeb = false;
+        this.hasDiffAfterSanitizing = false;
+        this.validationErrors = e.getValidationErrors();
+        this.output = "";
+    }
+
+    public HtmlValidationResult(String output) {
+        this.output = output;
+        this.okForWeb = true;
+        this.validationErrors = Collections.emptyList();
+        this.hasDiffAfterSanitizing = true;
+    }
+
+    @Override
+    public String toString() {
+        return "[ " + getClass().getSimpleName() + ((this.okForWeb) ? " OK for web" : "") + "\n" + String.join(", ", validationErrors) + String.join("\n", this.output) + "]";
+    }
+}

--- a/src/main/java/no/digipost/sanitizing/HtmlValidator.java
+++ b/src/main/java/no/digipost/sanitizing/HtmlValidator.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) Posten Norge AS
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.sanitizing;
+
+import no.digipost.sanitizing.exception.ValidationException;
+import no.digipost.sanitizing.internal.PolicyFactoryProvider;
+
+import java.nio.charset.StandardCharsets;
+
+import static no.digipost.sanitizing.HtmlValidationResult.HTML_EVERYTHING_OK;
+
+public class HtmlValidator {
+
+    private DigipostValidatingHtmlSanitizer digipostValidatingHtmlSanitizer;
+
+    public HtmlValidator() {
+        this.digipostValidatingHtmlSanitizer = new DigipostValidatingHtmlSanitizer();
+    }
+
+    public HtmlValidationResult valider(byte[] content) {
+        try {
+            final String input = new String(content, StandardCharsets.UTF_8);
+            final String output = this.digipostValidatingHtmlSanitizer.sanitize(input, PolicyFactoryProvider.API_HTML);
+            if (input.equals(output)) {
+                return HTML_EVERYTHING_OK;
+            } else {
+                return new HtmlValidationResult(output);
+            }
+        } catch (ValidationException e) {
+            return new HtmlValidationResult(e);
+        }
+    }
+}

--- a/src/test/java/no/digipost/sanitizing/HtmlValidatorTest.java
+++ b/src/test/java/no/digipost/sanitizing/HtmlValidatorTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) Posten Norge AS
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.sanitizing;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HtmlValidatorTest {
+
+    @Test
+    void enkle_tilfeller_skal_være_helt_ok() {
+        final HtmlValidationResult valider = new HtmlValidator().valider("<html></html>".getBytes());
+
+        assertTrue(valider.okForWeb);
+        assertSame(valider, HtmlValidationResult.HTML_EVERYTHING_OK);
+    }
+
+    @Test
+    void ikke_avsluttet_tag_skal_avsluttes() {
+        final HtmlValidationResult valider = new HtmlValidator().valider("<html><body></html>".getBytes());
+
+        assertTrue(valider.okForWeb);
+        assertEquals(valider.toString(), "[ HtmlValidationResult OK for web\n" +
+            "<html><body></body></html>]");
+    }
+
+    @Test
+    void lenker_skal_få_rel_target() {
+        final HtmlValidationResult valider = new HtmlValidator().valider(("<!doctype html>\n" +
+            "<html lang=\"no\">\n" +
+            "<head>\n" +
+            "    <meta charset=\"utf-8\">\n" +
+            "    <title>Posten Digipost</title>\n" +
+            "</head>\n" +
+            "<body id=\"Digipost\">\n" +
+            "<h1>Digipost</h1>\n" +
+            "</body>\n" +
+            "</html>\n").getBytes());
+
+        assertTrue(valider.okForWeb);
+        assertEquals(valider.toString(), "[ HtmlValidationResult OK for web\n" +
+            "<!doctype html>\n" +
+            "<html lang=\"no\"><head><meta charset=\"utf-8\" /><title>Posten Digipost</title></head><body id=\"Digipost\">\n" +
+            "<h1>Digipost</h1>\n" +
+            "</body></html>\n" +
+            "]");
+    }
+
+    @Test
+    void javascript_skal_kaste_exception() {
+        final HtmlValidationResult valider = new HtmlValidator().valider("<html><body><script/></body></html>".getBytes());
+
+        assertFalse(valider.okForWeb);
+        assertEquals(valider.toString(), "[ HtmlValidationResult\n" +
+            "Found HTML policy violation. Tag name: script]");
+    }
+
+    @Test
+    void gal_css_skal_kaste_exception() {
+        final HtmlValidationResult valider = new HtmlValidator().valider("<html><body><style>*   {color:red;}</style></body></html>".getBytes());
+
+        assertFalse(valider.okForWeb);
+        assertEquals(valider.toString(), "[ HtmlValidationResult\n" +
+            "CSS in style-element is invalid., CSS selector not found. Indicates illegal css.]");
+    }
+
+    @Test
+    void ulovlig_css_skal_kaste_exception() {
+        final HtmlValidationResult valider = new HtmlValidator().valider("<html><body><style>.per{display:none;}</style></body></html>".getBytes());
+
+        assertFalse(valider.okForWeb);
+        assertEquals(valider.toString(), "[ HtmlValidationResult\n" +
+            "Value 'none' is not allowed for property 'display'.]");
+    }
+}


### PR DESCRIPTION
Vi trenger et enkelt api å sende inn html til og få et format tilbake
som forteller noe om hva valideringen betyr.

ValidationResult har to public boolean:

`okForWeb` true vil si at alt er ok og kan sendes inn. Hvis false er det
umulig å sende inn dokumentet.

`hasDiffAfterSanitizing` sier noe om saniteringen faktisk utfører endringer
i dokumentet. Det vil si at hvis en avsender ikke endrer dokumentet før
innsending til Digipost så vil Digipost endre html-en før det sendes til
en mottager av meldingen.

Siden `okForWeb=false` kaster exception følger det at det er 3 tilstander
i valideringsresultatet:

ok for web og ingen diff (true, false)
ok for web og melding vil endres (true, true)
ikke ok for web (false, true/false)