### PR TITLE
Legger til legacy HTML-validator som ble brukt tidligere.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+target/*
+.idea/*
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>digipost-html-validator</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>0-SNAPSHOT</version>
     <description>Validering og sanitering av HTML som skal sendes til Digipost</description>
     <name>digipost-html-validator</name>
 

--- a/src/main/java/no/digipost/sanitizing/DigipostValidatingHtmlSanitizer.java
+++ b/src/main/java/no/digipost/sanitizing/DigipostValidatingHtmlSanitizer.java
@@ -25,7 +25,7 @@ public class DigipostValidatingHtmlSanitizer {
 
     public static void main(String[] args) {
         final String sanitize = new DigipostValidatingHtmlSanitizer()
-            .sanitize(args[0], PolicyFactoryProvider.API_HTML);
+            .sanitize(args[0], PolicyFactoryProvider.getPolicyFactory());
 
         System.out.println(sanitize);
     }

--- a/src/main/java/no/digipost/sanitizing/HtmlValidator.java
+++ b/src/main/java/no/digipost/sanitizing/HtmlValidator.java
@@ -19,21 +19,28 @@ import no.digipost.sanitizing.exception.ValidationException;
 import no.digipost.sanitizing.internal.PolicyFactoryProvider;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 
 import static no.digipost.sanitizing.HtmlValidationResult.HTML_EVERYTHING_OK;
 
 public class HtmlValidator {
 
     private DigipostValidatingHtmlSanitizer digipostValidatingHtmlSanitizer;
+    private Clock clock;
 
     public HtmlValidator() {
+        this(Clock.systemDefaultZone());
+    }
+
+    public HtmlValidator(Clock clock) {
+        this.clock = clock;
         this.digipostValidatingHtmlSanitizer = new DigipostValidatingHtmlSanitizer();
     }
 
     public HtmlValidationResult valider(byte[] content) {
         try {
             final String input = new String(content, StandardCharsets.UTF_8);
-            final String output = this.digipostValidatingHtmlSanitizer.sanitize(input, PolicyFactoryProvider.API_HTML);
+            final String output = this.digipostValidatingHtmlSanitizer.sanitize(input, PolicyFactoryProvider.getPolicyFactory(clock.instant()));
             if (input.equals(output)) {
                 return HTML_EVERYTHING_OK;
             } else {

--- a/src/main/java/no/digipost/sanitizing/internal/PolicyFactoryProvider.java
+++ b/src/main/java/no/digipost/sanitizing/internal/PolicyFactoryProvider.java
@@ -17,9 +17,29 @@ package no.digipost.sanitizing.internal;
 
 import org.owasp.html.PolicyFactory;
 
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
 final public class PolicyFactoryProvider {
 
-    public static final PolicyFactory API_HTML = ApiHtmlValidatorPolicy.ALLOW_STYLE_ELEMENT_POLICY;
+    public static final Instant V2_IN_EFFECT = ZonedDateTime.of(2019, 6,4,7,10,0,0, ZoneOffset.UTC).toInstant();
+
+    /**
+     *
+     * @return the current PolicyFactory used by digipost
+     */
+    public static PolicyFactory getPolicyFactory(){
+        return getPolicyFactory(Instant.now());
+    }
+
+    public static PolicyFactory getPolicyFactory(Instant documentCreationDate){
+        if(documentCreationDate.isBefore(V2_IN_EFFECT)) {
+            return ApiHtmlValidatorPolicy.V1_VALIDATE_ONLY_HTML_POLICY;
+        }else {
+            return ApiHtmlValidatorPolicy.V2_VALIDATE_HTML_AND_CSS_POLICY;
+        }
+    }
 
     public static ErrorCollectingHtmlChangeListener errorCollector() {
         return new ErrorCollectingHtmlChangeListener();

--- a/src/test/java/no/digipost/sanitizing/HtmlValidatorTestV1.java
+++ b/src/test/java/no/digipost/sanitizing/HtmlValidatorTestV1.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.sanitizing;
+
+import no.digipost.sanitizing.internal.PolicyFactoryProvider;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static no.digipost.sanitizing.internal.PolicyFactoryProvider.V2_IN_EFFECT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HtmlValidatorTestV1 {
+
+    private final HtmlValidator V1_validator = new HtmlValidator(Clock.fixed(PolicyFactoryProvider.V2_IN_EFFECT.minusSeconds(1), ZoneOffset.UTC));
+
+    @Test
+    void enkle_tilfeller_skal_være_helt_ok() {
+        final HtmlValidationResult valider = V1_validator.valider("<html></html>".getBytes());
+
+        assertTrue(valider.okForWeb);
+        assertSame(valider, HtmlValidationResult.HTML_EVERYTHING_OK);
+    }
+
+    @Test
+    void ikke_avsluttet_tag_skal_avsluttes() {
+        final HtmlValidationResult valider = V1_validator.valider("<html><body></html>".getBytes());
+
+        assertTrue(valider.okForWeb);
+        assertEquals(valider.toString(), "[ HtmlValidationResult OK for web\n" +
+            "<html><body></body></html>]");
+    }
+
+    @Test
+    void style_paa_attribute_tilfeller_skal_være_helt_ok() {
+        final HtmlValidationResult valider = V1_validator.valider("<html><body><p style=\"margin-right:1em\">Hallo</p></body></html>".getBytes());
+
+        assertTrue(valider.okForWeb);
+        assertSame(valider, HtmlValidationResult.HTML_EVERYTHING_OK);
+    }
+
+    @Test
+    void feil_om_css_i_style_attribute_ikke_er_whitelisted() {
+        final HtmlValidationResult valider = V1_validator.valider("<html><body><p style=\"display:none\">Hallo</p></body></html>".getBytes());
+
+        assertFalse(valider.okForWeb);
+    }
+
+    @Test
+    void lenker_skal_få_rel_target() {
+        final HtmlValidationResult valider = V1_validator.valider(("<!doctype html>\n" +
+            "<html lang=\"no\">\n" +
+            "<head>\n" +
+            "    <meta charset=\"utf-8\">\n" +
+            "    <title>Posten Digipost</title>\n" +
+            "</head>\n" +
+            "<body id=\"Digipost\">\n" +
+            "<h1>Digipost</h1>\n" +
+            "</body>\n" +
+            "</html>\n").getBytes());
+
+        assertTrue(valider.okForWeb);
+        assertEquals(valider.toString(), "[ HtmlValidationResult OK for web\n" +
+            "<!doctype html>\n" +
+            "<html lang=\"no\"><head><meta charset=\"utf-8\" /><title>Posten Digipost</title></head><body id=\"Digipost\">\n" +
+            "<h1>Digipost</h1>\n" +
+            "</body></html>\n" +
+            "]");
+    }
+
+    @Test
+    void javascript_skal_kaste_exception() {
+        final HtmlValidationResult valider = V1_validator.valider("<html><body><script/></body></html>".getBytes());
+
+        assertFalse(valider.okForWeb);
+        assertEquals(valider.toString(), "[ HtmlValidationResult\n" +
+            "Found HTML policy violation. Tag name: script]");
+    }
+    
+    @Test
+    void css_i_style_skal_fjernes() {
+        final String html = "<html><body><style>.per{display:none;}</style></body></html>";
+        final HtmlValidationResult valider = V1_validator.valider(html.getBytes());
+
+        assertTrue(valider.okForWeb);
+        assertTrue(valider.hasDiffAfterSanitizing);
+    }
+}

--- a/src/test/java/no/digipost/sanitizing/internal/HtmlSanitizerBrowserTestBed.java
+++ b/src/test/java/no/digipost/sanitizing/internal/HtmlSanitizerBrowserTestBed.java
@@ -30,7 +30,7 @@ public class HtmlSanitizerBrowserTestBed {
     public static void main(String[] args) throws Exception {
         String html = IOUtils.toString(HtmlSanitizerBrowserTestBed.class.getResourceAsStream("testInput.html"), UTF_8);
 
-        String sanitizedHtml = validatingHtmlSanitizer.sanitize(html, ApiHtmlValidatorPolicy.ALLOW_STYLE_ELEMENT_POLICY);
+        String sanitizedHtml = validatingHtmlSanitizer.sanitize(html, ApiHtmlValidatorPolicy.V2_VALIDATE_HTML_AND_CSS_POLICY);
 
         File htmlFile = File.createTempFile("sanitizer-test", "html");
         IOUtils.write(sanitizedHtml, new FileOutputStream(htmlFile), UTF_8);

--- a/src/test/java/no/digipost/sanitizing/internal/RichHtmlValidatorTest.java
+++ b/src/test/java/no/digipost/sanitizing/internal/RichHtmlValidatorTest.java
@@ -65,7 +65,7 @@ public class RichHtmlValidatorTest {
 
     @Test
     public void should_preserve_doctype_html() {
-        String validatedHtml = validator.sanitize("<!DOCTYPE html><div><p>Content</p></div>", ApiHtmlValidatorPolicy.ALLOW_STYLE_ELEMENT_POLICY);
+        String validatedHtml = validator.sanitize("<!DOCTYPE html><div><p>Content</p></div>", PolicyFactoryProvider.getPolicyFactory());
         assertEquals("<!doctype html><div><p>Content</p></div>", validatedHtml);
     }
 
@@ -161,7 +161,7 @@ public class RichHtmlValidatorTest {
     @Test
     public void skal_ikke_tillate_base_href() {
         try {
-            validator.sanitize("<html><head><base target=\"_blank\" href=\"http://www.evil.com/\"/></head><body>asdf</body></html>", ApiHtmlValidatorPolicy.ALLOW_STYLE_ELEMENT_POLICY);
+            validator.sanitize("<html><head><base target=\"_blank\" href=\"http://www.evil.com/\"/></head><body>asdf</body></html>", ApiHtmlValidatorPolicy.V2_VALIDATE_HTML_AND_CSS_POLICY);
             fail("Should fail");
         } catch (ValidationException dae) {
             assertEquals("Found HTML policy violation: Tag name: base, attribute(s): href", dae.getValidationErrors().get(0));
@@ -171,9 +171,9 @@ public class RichHtmlValidatorTest {
 
     @Test
     public void skal_tillate_et_begrenset_sett_metaattributter() {
-        validator.sanitize("<meta http-equiv=\"Content-Type\" content=\"text/html;charset=utf-8\">", ApiHtmlValidatorPolicy.ALLOW_STYLE_ELEMENT_POLICY);
-        validator.sanitize("<meta http-equiv=\"content-type\" content=\"text/html;charset=UTF-8\">", ApiHtmlValidatorPolicy.ALLOW_STYLE_ELEMENT_POLICY);
-        validator.sanitize("<meta name=\"viewport\" content=\"user-scalable = yes\">", ApiHtmlValidatorPolicy.ALLOW_STYLE_ELEMENT_POLICY);
+        validator.sanitize("<meta http-equiv=\"Content-Type\" content=\"text/html;charset=utf-8\">", ApiHtmlValidatorPolicy.V2_VALIDATE_HTML_AND_CSS_POLICY);
+        validator.sanitize("<meta http-equiv=\"content-type\" content=\"text/html;charset=UTF-8\">", ApiHtmlValidatorPolicy.V2_VALIDATE_HTML_AND_CSS_POLICY);
+        validator.sanitize("<meta name=\"viewport\" content=\"user-scalable = yes\">", ApiHtmlValidatorPolicy.V2_VALIDATE_HTML_AND_CSS_POLICY);
     }
 
     @Test
@@ -184,24 +184,24 @@ public class RichHtmlValidatorTest {
 
     @Test
     public void skal_tillate_maillenker_uten_target_blank() {
-        validator.sanitize("<a href=\"mailto:hei@example.org\">Klikk for mail</a>", ApiHtmlValidatorPolicy.ALLOW_STYLE_ELEMENT_POLICY);
+        validator.sanitize("<a href=\"mailto:hei@example.org\">Klikk for mail</a>", ApiHtmlValidatorPolicy.V2_VALIDATE_HTML_AND_CSS_POLICY);
     }
 
     @Test
     public void skal_bruke_target_blank_på_lenker_ved_andre_targets() {
-        String validatedHtml = validator.sanitize("<a href=\"http://example.org\" target=\"_self\">Clicky clicky</a>", ApiHtmlValidatorPolicy.ALLOW_STYLE_ELEMENT_POLICY);
+        String validatedHtml = validator.sanitize("<a href=\"http://example.org\" target=\"_self\">Clicky clicky</a>", ApiHtmlValidatorPolicy.V2_VALIDATE_HTML_AND_CSS_POLICY);
         assertEquals("<a href=\"http://example.org\" target=\"_blank\" rel=\"nofollow noreferrer noopener\">Clicky clicky</a>", validatedHtml);
     }
 
     @Test
     public void skal_legge_på_target_blank_ved_manglende_target() {
-        String validatedHtml = validator.sanitize("<a href=\"http://example.org\">Clicky clicky</a>", ApiHtmlValidatorPolicy.ALLOW_STYLE_ELEMENT_POLICY);
+        String validatedHtml = validator.sanitize("<a href=\"http://example.org\">Clicky clicky</a>", ApiHtmlValidatorPolicy.V2_VALIDATE_HTML_AND_CSS_POLICY);
         assertEquals("<a href=\"http://example.org\" target=\"_blank\" rel=\"nofollow noreferrer noopener\">Clicky clicky</a>", validatedHtml);
     }
 
     private void assertValid(String html) {
         try {
-            validator.sanitize(html, ApiHtmlValidatorPolicy.ALLOW_STYLE_ELEMENT_POLICY);
+            validator.sanitize(html, ApiHtmlValidatorPolicy.V2_VALIDATE_HTML_AND_CSS_POLICY);
         } catch (ValidationException dae) {
             if (!dae.getValidationErrors().isEmpty()) {
                 fail("Should be valid html, but failed due to " + dae.getMessage());
@@ -212,7 +212,7 @@ public class RichHtmlValidatorTest {
 
     private void assertInvalid(String html) {
         try {
-            validator.sanitize(html, ApiHtmlValidatorPolicy.ALLOW_STYLE_ELEMENT_POLICY);
+            validator.sanitize(html, ApiHtmlValidatorPolicy.V2_VALIDATE_HTML_AND_CSS_POLICY);
             fail("Should fail");
         } catch (ValidationException dae) {
             if (dae.getValidationErrors().isEmpty()) {


### PR DESCRIPTION
Dette for å fortsette å muliggjøre at gamle dokumenter kan bli validert med samme forutsetninger som da de ble sendt inn.