### PR TITLE
Bump dependencies

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -12,14 +12,13 @@ specific language governing permissions and limitations
 under the License.
 
 This project includes:
-  Animal Sniffer Annotations under MIT license
   Checker Qual under The MIT License
   digipost-html-validator under Apache License, Version 2.0
   error-prone annotations under Apache 2.0
   FindBugs-jsr305 under The Apache Software License, Version 2.0
   Guava InternalFutureFailureAccess and InternalFutures under The Apache Software License, Version 2.0
   Guava ListenableFuture only under The Apache Software License, Version 2.0
-  Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
+  Guava: Google Core Libraries for Java under Apache License, Version 2.0
   J2ObjC Annotations under The Apache Software License, Version 2.0
   OWASP Java HTML Sanitizer under Apache License, Version 2.0
   SLF4J API Module under MIT License

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.5.2</version>
+                <version>5.8.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -55,28 +55,28 @@
         <dependency>
             <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
             <artifactId>owasp-java-html-sanitizer</artifactId>
-            <version>20191001.1</version>
+            <version>20211018.2</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>27.1-jre</version>
+            <version>31.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.26</version>
+            <version>1.7.32</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>2.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-            <version>2.1</version>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -102,7 +102,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
@@ -110,7 +110,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.0.0-M2</version>
+                    <version>3.0.0-M3</version>
                     <configuration>
                         <rules>
                             <requireMavenVersion>
@@ -127,7 +127,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M3</version>
+                    <version>3.0.0-M5</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>

--- a/src/main/java/no/digipost/sanitizing/HtmlValidator.java
+++ b/src/main/java/no/digipost/sanitizing/HtmlValidator.java
@@ -25,8 +25,8 @@ import static no.digipost.sanitizing.HtmlValidationResult.HTML_EVERYTHING_OK;
 
 public class HtmlValidator {
 
-    private DigipostValidatingHtmlSanitizer digipostValidatingHtmlSanitizer;
-    private Clock clock;
+    private final DigipostValidatingHtmlSanitizer digipostValidatingHtmlSanitizer;
+    private final Clock clock;
 
     public HtmlValidator() {
         this(Clock.systemDefaultZone());

--- a/src/main/java/no/digipost/sanitizing/exception/CSSValidationException.java
+++ b/src/main/java/no/digipost/sanitizing/exception/CSSValidationException.java
@@ -17,7 +17,7 @@ package no.digipost.sanitizing.exception;
 
 import java.util.List;
 
-final public class CSSValidationException extends ValidationException {
+public final class CSSValidationException extends ValidationException {
 
 	public CSSValidationException(List<String> validationErrors) {
 		super(validationErrors);

--- a/src/main/java/no/digipost/sanitizing/exception/HTMLValidationException.java
+++ b/src/main/java/no/digipost/sanitizing/exception/HTMLValidationException.java
@@ -15,8 +15,6 @@
  */
 package no.digipost.sanitizing.exception;
 
-import no.digipost.sanitizing.exception.ValidationException;
-
 import java.util.List;
 
 public class HTMLValidationException extends ValidationException {

--- a/src/main/java/no/digipost/sanitizing/internal/PolicyFactoryProvider.java
+++ b/src/main/java/no/digipost/sanitizing/internal/PolicyFactoryProvider.java
@@ -21,7 +21,9 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
-final public class PolicyFactoryProvider {
+public final class PolicyFactoryProvider {
+
+    private PolicyFactoryProvider() {}
 
     public static final Instant V2_IN_EFFECT = ZonedDateTime.of(2019, 6,4,7,10,0,0, ZoneOffset.UTC).toInstant();
 

--- a/src/main/java/no/digipost/sanitizing/internal/StyleElementPreprocessor.java
+++ b/src/main/java/no/digipost/sanitizing/internal/StyleElementPreprocessor.java
@@ -60,12 +60,14 @@ final class StyleElementPreprocessor implements HtmlStreamEventProcessor {
         private static final String STYLE_TAG = "style";
 
         private static final Set<String> WORDS_IN_VALUE_BLACKLIST = new HashSet<>(Arrays.asList("javascript", "expression", "url(", "http://", "https://", "/*", "*/"));
-        private static final Map<String, String> HTML_ESCAPE_CHARS = new HashMap<String, String>() {{
-            put("&", "&amp;");
-            put("<", "&lt;");
-            put(">", "&gt;");
-            put("/", "&#x2F;");
-        }};
+        private static final Map<String, String> HTML_ESCAPE_CHARS = new HashMap<>();
+
+        static{
+            HTML_ESCAPE_CHARS.put("&", "&amp;");
+            HTML_ESCAPE_CHARS.put("<", "&lt;");
+            HTML_ESCAPE_CHARS.put(">", "&gt;");
+            HTML_ESCAPE_CHARS.put("/", "&#x2F;");
+        };
 
         // check that css is valid format. No dangling selectors (i.e. text) : (?:([\.\#\-\w\s\: \[\],]+)\s*\{([^}]+)\}\s*)+
         private static final Pattern completeCssPattern = Pattern.compile("(?:([\\.\\#\\-\\w\\s\\: \\[\\],]+)\\s*\\{([^}]+)\\}\\s*)+");

--- a/src/test/java/no/digipost/sanitizing/DigipostValidatingHtmlSanitizerTest.java
+++ b/src/test/java/no/digipost/sanitizing/DigipostValidatingHtmlSanitizerTest.java
@@ -80,6 +80,19 @@ class DigipostValidatingHtmlSanitizerTest {
         assertThat(thrown.getValidationErrors().get(0), equalTo("CSS in style-element is invalid."));
     }
 
+    @Test
+    void should_fail_script_inside_style_element() {
+        // Test for CVE_2021_42575
+        CSSValidationException thrown =
+            assertThrows(CSSValidationException.class,
+                () -> DigipostValidatingHtmlSanitizer.main(new String[]{
+                    "<select><option><style><script>alert(1)</script></style></option></select>"
+                }),
+                "Expected main() to throw, but it didn't");
+
+        assertThat(thrown.getValidationErrors().get(0), equalTo("CSS in style-element is invalid."));
+    }
+
     @AfterEach
     void tearDown() {
         System.setOut(old);


### PR DESCRIPTION
Bump dependencies and add test for CVE-2021-42575 (which we were not affected by due to our strict style policy).

More information:
https://github.com/OWASP/java-html-sanitizer/releases/tag/release-20211018.2
https://docs.google.com/document/d/11SoX296sMS0XoQiQbpxc5pNxSdbJKDJkm5BDv0zrX50/edit
