### PR TITLE
Ikke inkluder sanitert html i valideringsresultat som standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 target/*
 .idea/*
 *.iml
+/target/
+/.project
+/.classpath
+/.settings/

--- a/README.md
+++ b/README.md
@@ -50,9 +50,15 @@ if(validationResult.okForWeb){
 }
 
 if(validationResult.hasDiffAfterSanitizing){ // Din html er endret på og er fremdele ok å sende inn.
-    System.out.println(validationResult.toString()); // vil skrive ut den nye html-en som du så kan bruke til å endre din html.
+    System.out.println(validationResult.toString()); // vil skrive ut valideringsresultat. Inkluderer ikke sanitert html.
 }
 ```
+
+Dersom du trenger å se på sanitert innhold gjennom `HtmlValidator`, kall den 
+overlastede varianten av `HtmlValidator.validate`, med to parametre, og angi 
+argumentet `includeSanitizedOnDifference` som `true`. Da vil vasket html inkluderes i 
+toString-dumpen over. *Merk* Vær forsiktig med å dumpe html i produksjon, dersom
+den inneholder sensitive data.
 
 # Hvorfor vasker vi HTML-kode som blir sendt til Digipost
 Generelt endrer vi ikke på innhold som blir sendt gjennom Digipost. Men HTML-validering er vanskelig. Å sørge

--- a/src/main/java/no/digipost/sanitizing/HtmlValidator.java
+++ b/src/main/java/no/digipost/sanitizing/HtmlValidator.java
@@ -37,14 +37,40 @@ public class HtmlValidator {
         this.digipostValidatingHtmlSanitizer = new DigipostValidatingHtmlSanitizer();
     }
 
+    /**
+     * Validate html and check sanitation differences.
+     *
+     * Same as <code>valider(content, false</code>.
+     *
+     * @param content HTML content to validate.
+     * @return result of validation.
+     */
     public HtmlValidationResult valider(byte[] content) {
+        return valider(content, false);
+    }
+
+    /**
+     *
+     * Validate HTML and check whether sanitations would produce differences.
+     *
+     * @param content Html contents to validate
+     * @param includeSanitizedOnDifference whether the entire sanitized html
+     *        should be included in the validation result. It can be viewed as
+     *        part of {@link HtmlValidationResult#toString}, but should normally
+     *        be skipped, due to size or sensitive data exposure risk.
+     *
+     * @return result of validation.
+     */
+    public HtmlValidationResult valider(byte[] content, boolean includeSanitizedOnDifference) {
         try {
             final String input = new String(content, StandardCharsets.UTF_8);
             final String output = this.digipostValidatingHtmlSanitizer.sanitize(input, PolicyFactoryProvider.getPolicyFactory(clock.instant()));
             if (input.equals(output)) {
                 return HTML_EVERYTHING_OK;
             } else {
-                return new HtmlValidationResult(output);
+                return new HtmlValidationResult(includeSanitizedOnDifference ? output:
+                    "Sanitized html result not shown. Specify the "
+                    + "includeSanitizedOnDifference parameter as true, if you need that.");
             }
         } catch (ValidationException e) {
             return new HtmlValidationResult(e);

--- a/src/test/java/no/digipost/sanitizing/HtmlValidatorTestV1.java
+++ b/src/test/java/no/digipost/sanitizing/HtmlValidatorTestV1.java
@@ -16,13 +16,12 @@
 package no.digipost.sanitizing;
 
 import no.digipost.sanitizing.internal.PolicyFactoryProvider;
+
 import org.junit.jupiter.api.Test;
 
 import java.time.Clock;
-import java.time.Instant;
 import java.time.ZoneOffset;
 
-import static no.digipost.sanitizing.internal.PolicyFactoryProvider.V2_IN_EFFECT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -42,7 +41,7 @@ class HtmlValidatorTestV1 {
 
     @Test
     void ikke_avsluttet_tag_skal_avsluttes() {
-        final HtmlValidationResult valider = V1_validator.valider("<html><body></html>".getBytes());
+        final HtmlValidationResult valider = V1_validator.valider("<html><body></html>".getBytes(), true);
 
         assertTrue(valider.okForWeb);
         assertEquals(valider.toString(), "[ HtmlValidationResult OK for web\n" +
@@ -75,7 +74,7 @@ class HtmlValidatorTestV1 {
             "<body id=\"Digipost\">\n" +
             "<h1>Digipost</h1>\n" +
             "</body>\n" +
-            "</html>\n").getBytes());
+            "</html>\n").getBytes(), true);
 
         assertTrue(valider.okForWeb);
         assertEquals(valider.toString(), "[ HtmlValidationResult OK for web\n" +
@@ -94,7 +93,7 @@ class HtmlValidatorTestV1 {
         assertEquals(valider.toString(), "[ HtmlValidationResult\n" +
             "Found HTML policy violation. Tag name: script]");
     }
-    
+
     @Test
     void css_i_style_skal_fjernes() {
         final String html = "<html><body><style>.per{display:none;}</style></body></html>";

--- a/src/test/java/no/digipost/sanitizing/HtmlValidatorTestV2.java
+++ b/src/test/java/no/digipost/sanitizing/HtmlValidatorTestV2.java
@@ -16,6 +16,7 @@
 package no.digipost.sanitizing;
 
 import no.digipost.sanitizing.internal.PolicyFactoryProvider;
+
 import org.junit.jupiter.api.Test;
 
 import java.time.Clock;
@@ -40,7 +41,7 @@ class HtmlValidatorTestV2 {
 
     @Test
     void ikke_avsluttet_tag_skal_avsluttes() {
-        final HtmlValidationResult valider = V2_validator.valider("<html><body></html>".getBytes());
+        final HtmlValidationResult valider = V2_validator.valider("<html><body></html>".getBytes(), true);
 
         assertTrue(valider.okForWeb);
         assertEquals(valider.toString(), "[ HtmlValidationResult OK for web\n" +
@@ -58,7 +59,7 @@ class HtmlValidatorTestV2 {
             "<body id=\"Digipost\">\n" +
             "<h1>Digipost</h1>\n" +
             "</body>\n" +
-            "</html>\n").getBytes());
+            "</html>\n").getBytes(), true);
 
         assertTrue(valider.okForWeb);
         assertEquals(valider.toString(), "[ HtmlValidationResult OK for web\n" +


### PR DESCRIPTION
(HtmlValidator.validate) Legg til overlastet variant som gjør det mulig
å inkludere vasket html. Legg på litt JavaDoc.
(README.md) Klargjør at sanitert innhold ikke lenger vises automatisk,
og skisser hvordan man skrur det på.