### PR TITLE
Upgrade guava 31.0.1-jre -> 31.1-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>31.0.1-jre</version>
+            <version>31.1-jre</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Sårbarhet som klages på i digipost-api-client-java. Ser ikke ut som noe kritisk, men greit å oppgradere.

https://ossindex.sonatype.org/component/pkg:maven/com.google.guava/guava@31.0.1-jre?utm_source=ossindex-client
- 1 vulnerability found (6.2); https://ossindex.sonatype.org/vulnerability/sonatype-2020-0926