### PR TITLE
Remove Guava dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,12 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- Override Guava version of owasp-java-html-sanitizer to fix vulnerability -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>32.1.2-jre</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -56,11 +62,6 @@
             <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
             <artifactId>owasp-java-html-sanitizer</artifactId>
             <version>20211018.2</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>32.1.2-jre</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/no/digipost/sanitizing/internal/ApiHtmlValidatorPolicy.java
+++ b/src/main/java/no/digipost/sanitizing/internal/ApiHtmlValidatorPolicy.java
@@ -15,7 +15,6 @@
  */
 package no.digipost.sanitizing.internal;
 
-import com.google.common.collect.Lists;
 import org.owasp.html.AttributePolicy;
 import org.owasp.html.CssSchema;
 import org.owasp.html.ElementPolicy;
@@ -72,16 +71,14 @@ final class ApiHtmlValidatorPolicy {
 
     static {
         HashSet<String> defaultProperties = new HashSet<>(CssSchema.DEFAULT.allowedProperties());
-        defaultProperties.addAll(Lists.newArrayList(
-            "top"
-            , "bottom"
-            , "left"
-            , "right"
-            , "background"
-            , "page-break-before"
-            , "page-break-after"
-            , "page-break-inside"
-        ));
+        defaultProperties.add("top");
+        defaultProperties.add("bottom");
+        defaultProperties.add("left");
+        defaultProperties.add("right");
+        defaultProperties.add("background");
+        defaultProperties.add("page-break-before");
+        defaultProperties.add("page-break-after");
+        defaultProperties.add("page-break-inside");
         CSS_WHITELIST = Collections.unmodifiableSet(defaultProperties);
 
         final Predicate<String> allowAllValuesPredicate = (value) -> true;


### PR DESCRIPTION
There was only one usage of Guava and this was easy to replace with standard Java.

We still have Guava transitively through owasp-java-html-sanitizer. This dependency uses a vulnerable version of Guava, so we override it. I have therefore put it in dependencyManagement, which I guess makes more sense.