### PR TITLE
Upgrade sanitizer

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -12,14 +12,9 @@ specific language governing permissions and limitations
 under the License.
 
 This project includes:
-  Checker Qual under The MIT License
   digipost-html-validator under Apache License, Version 2.0
-  error-prone annotations under Apache 2.0
-  FindBugs-jsr305 under The Apache Software License, Version 2.0
-  Guava InternalFutureFailureAccess and InternalFutures under The Apache Software License, Version 2.0
-  Guava ListenableFuture only under The Apache Software License, Version 2.0
-  Guava: Google Core Libraries for Java under Apache License, Version 2.0
-  J2ObjC Annotations under Apache License, Version 2.0
+  Java 10 Shim under Apache License, Version 2.0
+  Java 8 Shim under Apache License, Version 2.0
   OWASP Java HTML Sanitizer under Apache License, Version 2.0
   SLF4J API Module under MIT License
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,12 +38,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- Override Guava version of owasp-java-html-sanitizer to fix vulnerability -->
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>32.1.2-jre</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -61,17 +55,17 @@
         <dependency>
             <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
             <artifactId>owasp-java-html-sanitizer</artifactId>
-            <version>20211018.2</version>
+            <version>20240325.1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.32</version>
+            <version>1.7.36</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.11.0</version>
+            <version>2.16.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/no/digipost/sanitizing/HtmlValidatorV2Test.java
+++ b/src/test/java/no/digipost/sanitizing/HtmlValidatorV2Test.java
@@ -19,22 +19,20 @@ import no.digipost.sanitizing.internal.PolicyFactoryProvider;
 import org.junit.jupiter.api.Test;
 
 import java.time.Clock;
-import java.time.Instant;
 import java.time.ZoneOffset;
 
-import static no.digipost.sanitizing.internal.PolicyFactoryProvider.V2_IN_EFFECT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class HtmlValidatorTestV1 {
+class HtmlValidatorV2Test {
 
-    private final HtmlValidator V1_validator = new HtmlValidator(Clock.fixed(PolicyFactoryProvider.V2_IN_EFFECT.minusSeconds(1), ZoneOffset.UTC));
+    private final HtmlValidator V2_validator = new HtmlValidator(Clock.fixed(PolicyFactoryProvider.V2_IN_EFFECT, ZoneOffset.UTC));
 
     @Test
     void enkle_tilfeller_skal_være_helt_ok() {
-        final HtmlValidationResult valider = V1_validator.valider("<html></html>".getBytes());
+        final HtmlValidationResult valider = V2_validator.valider("<html></html>".getBytes());
 
         assertTrue(valider.okForWeb);
         assertSame(valider, HtmlValidationResult.HTML_EVERYTHING_OK);
@@ -42,7 +40,7 @@ class HtmlValidatorTestV1 {
 
     @Test
     void ikke_avsluttet_tag_skal_avsluttes() {
-        final HtmlValidationResult valider = V1_validator.valider("<html><body></html>".getBytes());
+        final HtmlValidationResult valider = V2_validator.valider("<html><body></html>".getBytes());
 
         assertTrue(valider.okForWeb);
         assertEquals(valider.toString(), "[ HtmlValidationResult OK for web\n" +
@@ -50,23 +48,8 @@ class HtmlValidatorTestV1 {
     }
 
     @Test
-    void style_paa_attribute_tilfeller_skal_være_helt_ok() {
-        final HtmlValidationResult valider = V1_validator.valider("<html><body><p style=\"margin-right:1em\">Hallo</p></body></html>".getBytes());
-
-        assertTrue(valider.okForWeb);
-        assertSame(valider, HtmlValidationResult.HTML_EVERYTHING_OK);
-    }
-
-    @Test
-    void feil_om_css_i_style_attribute_ikke_er_whitelisted() {
-        final HtmlValidationResult valider = V1_validator.valider("<html><body><p style=\"display:none\">Hallo</p></body></html>".getBytes());
-
-        assertFalse(valider.okForWeb);
-    }
-
-    @Test
     void lenker_skal_få_rel_target() {
-        final HtmlValidationResult valider = V1_validator.valider(("<!doctype html>\n" +
+        final HtmlValidationResult valider = V2_validator.valider(("<!doctype html>\n" +
             "<html lang=\"no\">\n" +
             "<head>\n" +
             "    <meta charset=\"utf-8\">\n" +
@@ -88,19 +71,43 @@ class HtmlValidatorTestV1 {
 
     @Test
     void javascript_skal_kaste_exception() {
-        final HtmlValidationResult valider = V1_validator.valider("<html><body><script/></body></html>".getBytes());
+        final HtmlValidationResult valider = V2_validator.valider("<html><body><script/></body></html>".getBytes());
 
         assertFalse(valider.okForWeb);
         assertEquals(valider.toString(), "[ HtmlValidationResult\n" +
             "Found HTML policy violation. Tag name: script]");
     }
-    
+
     @Test
-    void css_i_style_skal_fjernes() {
-        final String html = "<html><body><style>.per{display:none;}</style></body></html>";
-        final HtmlValidationResult valider = V1_validator.valider(html.getBytes());
+    void gal_css_skal_kaste_exception() {
+        final HtmlValidationResult valider = V2_validator.valider("<html><body><style>*   {color:red;}</style></body></html>".getBytes());
+
+        assertFalse(valider.okForWeb);
+        assertEquals(valider.toString(), "[ HtmlValidationResult\n" +
+            "CSS in style-element is invalid., CSS selector not found. Indicates illegal css.]");
+    }
+
+    @Test
+    void ulovlig_css_skal_kaste_exception() {
+        final HtmlValidationResult valider = V2_validator.valider("<html><body><style>.per{display:none;}</style></body></html>".getBytes());
+
+        assertFalse(valider.okForWeb);
+        assertEquals(valider.toString(), "[ HtmlValidationResult\n" +
+            "Value 'none' is not allowed for property 'display'.]");
+    }
+
+    @Test
+    void style_paa_attribute_tilfeller_skal_være_helt_ok() {
+        final HtmlValidationResult valider = V2_validator.valider("<html><body><p style=\"margin-right:1em\">Hallo</p></body></html>".getBytes());
 
         assertTrue(valider.okForWeb);
-        assertTrue(valider.hasDiffAfterSanitizing);
+        assertSame(valider, HtmlValidationResult.HTML_EVERYTHING_OK);
+    }
+
+    @Test
+    void feil_om_css_i_style_attribute_ikke_er_whitelisted() {
+        final HtmlValidationResult valider = V2_validator.valider("<html><body><p style=\"display:none\">Hallo</p></body></html>".getBytes());
+
+        assertFalse(valider.okForWeb);
     }
 }

--- a/src/test/java/no/digipost/sanitizing/internal/RichHtmlValidatorTest.java
+++ b/src/test/java/no/digipost/sanitizing/internal/RichHtmlValidatorTest.java
@@ -17,6 +17,7 @@ package no.digipost.sanitizing.internal;
 
 import no.digipost.sanitizing.DigipostValidatingHtmlSanitizer;
 import no.digipost.sanitizing.exception.ValidationException;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -190,13 +191,19 @@ public class RichHtmlValidatorTest {
     @Test
     public void skal_bruke_target_blank_på_lenker_ved_andre_targets() {
         String validatedHtml = validator.sanitize("<a href=\"http://example.org\" target=\"_self\">Clicky clicky</a>", ApiHtmlValidatorPolicy.V2_VALIDATE_HTML_AND_CSS_POLICY);
-        assertEquals("<a href=\"http://example.org\" target=\"_blank\" rel=\"nofollow noreferrer noopener\">Clicky clicky</a>", validatedHtml);
+        assertTrue(validatedHtml.contains("target=\"_blank\""));
+        assertTrue(validatedHtml.contains("noopener"));
+        assertTrue(validatedHtml.contains("noreferrer"));
+        assertTrue(validatedHtml.contains("nofollow"));
     }
 
     @Test
     public void skal_legge_på_target_blank_ved_manglende_target() {
         String validatedHtml = validator.sanitize("<a href=\"http://example.org\">Clicky clicky</a>", ApiHtmlValidatorPolicy.V2_VALIDATE_HTML_AND_CSS_POLICY);
-        assertEquals("<a href=\"http://example.org\" target=\"_blank\" rel=\"nofollow noreferrer noopener\">Clicky clicky</a>", validatedHtml);
+        assertTrue(validatedHtml.contains("target=\"_blank\""));
+        assertTrue(validatedHtml.contains("noopener"));
+        assertTrue(validatedHtml.contains("noreferrer"));
+        assertTrue(validatedHtml.contains("nofollow"));
     }
 
     // https://nvd.nist.gov/vuln/detail/CVE-2021-42575


### PR DESCRIPTION
## Upgrade OWASP sanitizer

This upgrades the OWASP sanitizer library to the latest version. Guava
is removed from this version.
https://github.com/OWASP/java-html-sanitizer/releases/tag/release-20220608.1

The order of noreferrer, nofollow, noopener is apparently random now, so
I had to rewrite those tests to not care about order
(https://github.com/OWASP/java-html-sanitizer/issues/336).

## Rename test files to make them run

The files should match the expected name pattern so that are executed
through maven.