### PR TITLE
Fjern noscript for å hindre sårbarhet med XSS

### DIFF
--- a/src/main/java/no/digipost/sanitizing/internal/ApiHtmlValidatorPolicy.java
+++ b/src/main/java/no/digipost/sanitizing/internal/ApiHtmlValidatorPolicy.java
@@ -175,7 +175,7 @@ final class ApiHtmlValidatorPolicy {
         .allowElements(KITH_TAGS)
         .allowElements(
             "html", "body", "head", "title", "meta", "base", "style",
-            "a", "label", "noscript", "h1", "h2", "h3", "h4", "h5", "h6",
+            "a", "label", "h1", "h2", "h3", "h4", "h5", "h6",
             "p", "i", "b", "u", "strong", "em", "small", "big", "pre", "code",
             "cite", "samp", "sub", "sup", "strike", "center", "blockquote",
             "hr", "br", "col", "font", "map", "span", "div", "img",


### PR DESCRIPTION
Fjerner noscript for å hindre CVE-2025-66021.
Tanken er at denne ikke blir brukt for de
virksomhetene som sender html brev. Hvis
dette er mye brukt må vi ta stilling til det.
Prosjektet har ingen fiks på dette selv, og
usikkert på om det kommer.